### PR TITLE
debian: Run as ndn user with its home directory

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,8 @@ Vcs-Browser: https://github.com/named-data/NFD
 
 Package: nfd
 Architecture: any
-Depends: lsb-base (>= 3.0-6),
+Depends: libcap2-bin,
+         lsb-base (>= 3.0-6),
          ndnsec-tools,
          ${misc:Depends},
          ${python:Depends},

--- a/debian/nfd-init.service
+++ b/debian/nfd-init.service
@@ -23,7 +23,7 @@ After=nfd.service
 ConditionPathExists=/etc/ndn/nfd-init.sh
 
 [Service]
-Environment=HOME=/var/lib/ndn/nfd
+Environment=HOME=/var/lib/ndn
 ExecStart=/bin/sh -ec 'sleep 2; . /etc/ndn/nfd-init.sh;'
 Type=oneshot
 RemainAfterExit=yes

--- a/debian/nfd.postinst
+++ b/debian/nfd.postinst
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = configure ]; then
+  # Add a user for all NDN related files and processes
+  adduser \
+      --system \
+      --quiet \
+      --home /var/lib/ndn \
+      --disabled-password \
+      --group \
+      ndn-user
+
+  # Set up nfd capabilities
+  # See https://named-data.net/doc/NFD/current/FAQ.html#how-to-run-nfd-as-non-root-user
+  setcap cap_net_raw,cap_net_admin=eip /usr/bin/nfd
+fi
+
+#DEBHELPER#
+
+exit 0

--- a/debian/nfd.service
+++ b/debian/nfd.service
@@ -30,7 +30,7 @@ After=network-online.target
 
 [Service]
 EnvironmentFile=-/etc/default/nfd
-Environment=HOME=/var/lib/ndn/nfd
+Environment=HOME=/var/lib/ndn
 ExecStart=/usr/bin/nfd --config /etc/ndn/nfd.conf ${OPTIONS}
 Restart=on-failure
 ProtectSystem=full

--- a/nfd.conf.sample.in
+++ b/nfd.conf.sample.in
@@ -5,8 +5,8 @@ general
   ; when not performing privileged tasks. NFD does not drop
   ; privileges by default.
 
-  ; user ndn-user
-  ; group ndn-user
+  user ndn-user
+  group ndn-user
 }
 
 log


### PR DESCRIPTION
Create and run as an `ndn` user with HOME=/var/lib/ndn, the same as in
the ndn-cxx package. Keys will be installed to /var/lib/ndn/.ndn by
programs from both packages, and the key store will be shared.

As part of this, the nfd binary needs to have some additional
capabilities set, which adds a build-dep on libcap2-bin for setcap.

We can’t run the nfd daemon as the ndn user from the start (using
systemd’s User key) as it does its own socket setup, which requires root
privileges. The nfd configuration has been changed to drop privileges
and run as ndn after startup. nfd does not support systemd (or inetd)
socket activation.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T13932