### PR TITLE
debian: Ensure journald identifiers are correct in systemd units

### DIFF
--- a/debian/nfd-init.service
+++ b/debian/nfd-init.service
@@ -29,5 +29,8 @@ User=ndn-user
 Type=oneshot
 RemainAfterExit=yes
 
+# Set the syslog identifier so it is not 'sh'
+SyslogIdentifier=nfd-init.sh
+
 [Install]
 WantedBy=multi-user.target

--- a/debian/nfd-keygen.service
+++ b/debian/nfd-keygen.service
@@ -33,5 +33,8 @@ Type=oneshot
 RemainAfterExit=yes
 User=ndn-user
 
+# Set the syslog identifier so it is not 'sh'
+SyslogIdentifier=nfd-keygen
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It’s not very helpful for all the logging to show up in the journal as
the `sh` process — fix that by either un-wrapping the process from `sh`,
or setting SyslogIdentifier to override the process name.

This means output will now show up in the journal identified as
`nfd-init.sh`, `nfd-keygen` or `nfd`.

Signed-off-by: Philip Withnall <withnall@endlessm.com>